### PR TITLE
[6.2.0] Support I18n through human_attribute_name

### DIFF
--- a/lib/wice/grid_renderer.rb
+++ b/lib/wice/grid_renderer.rb
@@ -320,7 +320,7 @@ module Wice
         in_xlsx:                     true,
         in_html:                     true,
         model:                       nil, # will throw an exception with instructions
-        name:                        '',
+        name:                        nil,
         negation:                    ConfigurationProvider.value_for(:NEGATION_IN_STRING_FILTERS),
         ordering:                    true,
         table_alias:                 nil,
@@ -396,6 +396,10 @@ module Wice
 
         if options[:custom_filter]
 
+          if options[:name].nil?
+            options[:name] = db_column.model.human_attribute_name options[:attribute]
+          end
+
           custom_filter = if options[:custom_filter] == :auto
             -> { @grid.distinct_values_for_column(db_column) } # Thank God Ruby has higher order functions!!!
 
@@ -449,6 +453,9 @@ module Wice
         end # custom_filter
 
       end # attribute
+
+      # Default column name if not already overwited
+      options[:name] ||= ''
 
       vc = klass.new(block, options, @grid, table_name, main_table, custom_filter, @view)
 

--- a/lib/wice/wice_grid_serialized_query.rb
+++ b/lib/wice/wice_grid_serialized_query.rb
@@ -1,5 +1,5 @@
 class WiceGridSerializedQuery < ActiveRecord::Base  #:nodoc:
-  serialize :query
+  serialize :query, coder: YAML
 
   validates_uniqueness_of :name, scope: :grid_name, on: :create, message: 'A query with this name already exists'
 

--- a/wice_grid.gemspec
+++ b/wice_grid.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name          = 'wice_grid'
-  s.version       = '6.1.2'
+  s.version       = '6.2.0'
   s.authors       = ['Yuri Leikind and contributors', 'Modulotech']
-  s.email         = ['ciappa_m@modulotech.fr']
+  s.email         = ['ciappa_m@modulotech.fr', 'billau_l@modulotech.fr']
   s.homepage      = 'https://github.com/moduloTech/wice_grid'
   s.summary       = 'A Rails grid plugin to quickly create grids with sorting, pagination, and filters.'
   s.description   = 'A Rails grid plugin to create grids with sorting, pagination, and filters generated automatically based on column types. ' \
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'caxlsx',            ['~> 3.3.0']
 
   s.add_development_dependency('rake',  '~> 10.1')
-  s.add_development_dependency('byebug')
   s.add_development_dependency('appraisal')
 
   s.add_development_dependency('rspec', '~> 3.6.0')


### PR DESCRIPTION
When attribute: is provide to the column helper without a name: WiceGrid now use TheModel.human_attribute_name to get the column name from locals

Also Fix coder compatibility with Rails 7.1